### PR TITLE
Update readme clean install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ These are three simple examples of websites built with `elm-starter`:
 
 ![elm-starter](assets/dev/collection.png)
 
-# Characteristics
+## Characteristics
 
 * Generate a PWA (Progressive Web Application)
 * Mostly written in Elm
@@ -43,7 +43,7 @@ Slack's previews (note how different urls have different snapshot and meta-data)
 
 ![Slack's previews](assets/dev/slack-previews.jpg)
 
-# How to bootstrap a new project
+## How to bootstrap a new project
 
 `elm-starter` is not published in npm yet and it doesn't have a specific command to bootstrap a project, so the way it works now is cloning this repo.
 
@@ -81,7 +81,7 @@ Launches a server in the `build` folder.
 
 Open [http://localhost:9000](http://localhost:9000) to view it in the browser.
 
-# How to use `elm-starter` in existing Elm application
+## How to use `elm-starter` in existing Elm application
 
 Let's suppose your existing project is in `my-elm-app`
 
@@ -129,14 +129,14 @@ Let's suppose your existing project is in `my-elm-app`
     ```
 Done!
 
-# Netlify
+## Netlify
 
 When setting up the app with Netlify, input these in the deploy configuration:
 
 * Build command: `npm run build` (or `node ./src-elm-starter/starter.js start`)
 * Publish directory: `elm-stuff/elm-starter-files/build`
 
-# (\*) Applications working without Javascript
+## (\*) Applications working without Javascript
 
 Working without Javascript depends on the application. The `elm-starter` example works completely fine also without Javascript, the only missing thing is the smooth transition between pages.
 
@@ -150,7 +150,7 @@ The setup for these two cases is a bit different. `Browser.application` requires
 
 The working folder of `elm-starter` is `elm-stuff/elm-starter-files`. These files are automatically generated and should not be edited directly, unless during some debugging process.
 
-# Advanced stuff
+## Advanced stuff
 
 ## File generation
 
@@ -242,7 +242,7 @@ This data is also available in Elm through Flags.
 
 This is the object exposed by the compiler used to initialize the application.
 
-# Limitations
+## Limitations
 
 * Javascript and CSS to generate the initial `index.html` are actually strings :-(
 * `src-elm-starter/starter.js`, the core of `elm-starter`, is ~330 lines of Javascript. I wish it could be smaller
@@ -252,7 +252,7 @@ Note
 
 * The smooth rotational transition in the demo only works in Chrome. I realized it too late, but you get the picture
 
-# Non-goals
+## Non-goals
 
 Things that `elm-starter` is not expected to do
 
@@ -276,7 +276,7 @@ It cannot help you with
 * Server Rendering
 * SSR with (re)hydration
 
-# Similar projects
+## Similar projects
 
 These are other projects that can be used to bootstrap an Elm application or to generate a static site:
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The working folder of `elm-starter` is `elm-stuff/elm-starter-files`. These file
 
 Is possible to disable pre-rendering just passing an empty list to `Main.conf.urls`. In this case the app will work as "Full CSR" (Full Client-side Rendering)
 
-## How to customize your project.
+## How to customize your project
 
 The main two places where you can change stuff are:
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Example of the installed version, with and without Javascript enabled:
 
 These are three simple examples of websites built with `elm-starter`:
 
-* https://elm-starter.guupa.com/ ([Code](https://github.com/lucamug/elm-starter))
-* https://elm-todomvc.guupa.com/ ([Code](https://github.com/lucamug/elm-todomvc))
-* https://elm-spa-example.guupa.com/ ([Code](https://github.com/lucamug/elm-spa-example))
+* [https://elm-starter.guupa.com/](https://elm-starter.guupa.com/) ([Code](https://github.com/lucamug/elm-starter))
+* [https://elm-todomvc.guupa.com/](https://elm-todomvc.guupa.com/) ([Code](https://github.com/lucamug/elm-todomvc))
+* [https://elm-spa-example.guupa.com/](https://elm-spa-example.guupa.com/) ([Code](https://github.com/lucamug/elm-spa-example))
 
 ![elm-starter](assets/dev/collection.png)
 
@@ -98,7 +98,7 @@ Let's suppose your existing project is in `my-elm-app`
   * "description"
   * "author"
   * "twitterSite" - A reference to a Twitter handle (Just the id without "@")
-  * "twitterCreator" - Another Twitter handle, refer to [Twitter cards markups](https://developer.twitter.com/en/docs/  tweets/optimize-with-cards/overview/markup)
+  * "twitterCreator" - Another Twitter handle, refer to [Twitter cards markups]([https://developer.twitter.com/en/docs/](https://developer.twitter.com/en/docs/)  tweets/optimize-with-cards/overview/markup)
   * "version"
   * "homepage"
   * "license"
@@ -185,7 +185,7 @@ Moreover `Main.conf` is used by `src-elm-starter` to generate all the static fil
 
 ## elm-console-debug.js for nice console output
 
-Support https://github.com/kraklin/elm-debug-transformer out of the box for nice `Debug.log` messages in the console.
+Support [https://github.com/kraklin/elm-debug-transformer](https://github.com/kraklin/elm-debug-transformer) out of the box for nice `Debug.log` messages in the console.
 
 ## Changing meta-tags
 
@@ -203,7 +203,7 @@ Cmd.batch
     ]
 ```
 
-You can validate Twitter preview cards at https://cards-dev.twitter.com/validator
+You can validate Twitter preview cards at [https://cards-dev.twitter.com/validator](https://cards-dev.twitter.com/validator)
 
 ![elm-starter](assets/dev/twitter-card.jpg)
 
@@ -215,7 +215,7 @@ $ node_modules/.bin/elm reactor
 ```
 and check the page
 
-http://localhost:8000/src-elm-starter/Application.elm
+[http://localhost:8000/src-elm-starter/Application.elm](http://localhost:8000/src-elm-starter/Application.elm)
 
 ## Globally available objects
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Example of the installed version, with and without Javascript enabled:
 
 ![elm-starter](assets/dev/elm-starter.gif)
 
-
 ### Demos
 
 These are three simple examples of websites built with `elm-starter`:
@@ -18,18 +17,6 @@ These are three simple examples of websites built with `elm-starter`:
 * https://elm-spa-example.guupa.com/ ([Code](https://github.com/lucamug/elm-spa-example))
 
 ![elm-starter](assets/dev/collection.png)
-
-
-
-
-
-
-
-
-
-
-
-
 
 # Characteristics
 
@@ -55,13 +42,6 @@ Lighthouse report:
 Slack's previews (note how different urls have different snapshot and meta-data):
 
 ![Slack's previews](assets/dev/slack-previews.jpg)
-
-
-
-
-
-
-
 
 # How to bootstrap a new project
 
@@ -101,21 +81,6 @@ Launches a server in the `build` folder.
 
 Open [http://localhost:9000](http://localhost:9000) to view it in the browser.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 # How to use `elm-starter` in existing Elm application
 
 Let's suppose your existing project is in `my-elm-app`
@@ -141,8 +106,8 @@ Let's suppose your existing project is in `my-elm-app`
   * "snapshotHeight" - default: 350 px
   * "themeColor" - default: { "red": 15, "green": 85, "blue": 123 }
 
-* Add `node` dependencies with these commands 
-    
+* Add `node` dependencies with these commands
+
     ```
     $ npm install --save-dev chokidar-cli
     $ npm install --save-dev concurrently
@@ -152,7 +117,7 @@ Let's suppose your existing project is in `my-elm-app`
     $ npm install --save-dev puppeteer
     $ npm install --save-dev terser
     ```
-    
+
 * Add `src-elm-starter` as an extra `source-directory` in `elm.json`, the same as in `elm-starter/elm.json`
 * Add these commands to `package.json` (or run them directly)
     ```
@@ -164,34 +129,12 @@ Let's suppose your existing project is in `my-elm-app`
     ```
 Done!
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 # Netlify
 
 When setting up the app with Netlify, input these in the deploy configuration:
 
 * Build command: `npm run build` (or `node ./src-elm-starter/starter.js start`)
 * Publish directory: `elm-stuff/elm-starter-files/build`
-
-
-
-
-
-
-
-
 
 # (\*) Applications working without Javascript
 
@@ -207,14 +150,6 @@ The setup for these two cases is a bit different. `Browser.application` requires
 
 The working folder of `elm-starter` is `elm-stuff/elm-starter-files`. These files are automatically generated and should not be edited directly, unless during some debugging process.
 
-
-
-
-
-
-
-
-
 # Advanced stuff
 
 ## File generation
@@ -225,7 +160,6 @@ The working folder of `elm-starter` is `elm-stuff/elm-starter-files`. These file
     * [`manifest.json`](https://elm-starter.guupa.com/manifest.json)
     * [`service-worker.js`](https://elm-starter.guupa.com/service-worker.js)
     * [`robots.txt`](https://elm-starter.guupa.com/robots.txt)
-
 
 ## Disabling pre-rendering
 
@@ -246,7 +180,7 @@ The reason `Main.conf` is inside `Main.elm` is so that it can exchange data. For
 
 * `title`: `Main.conf` -> `Main`
 * `urls`: `Main.conf` <- `Main`
-    
+
 Moreover `Main.conf` is used by `src-elm-starter` to generate all the static files.
 
 ## elm-console-debug.js for nice console output
@@ -292,7 +226,7 @@ There are three global objects available
 `ElmStarter` contain metadata about the app:
 ```
 { commit: "abf04f3"   // coming from git
-, branch: "master"    // coming from git 
+, branch: "master"    // coming from git
 , env: "dev"          // can be "dev" or "prod"
 , version: "0.0.5"    // coming from package.json
 }
@@ -308,27 +242,6 @@ This data is also available in Elm through Flags.
 
 This is the object exposed by the compiler used to initialize the application.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 # Limitations
 
 * Javascript and CSS to generate the initial `index.html` are actually strings :-(
@@ -339,23 +252,16 @@ Note
 
 * The smooth rotational transition in the demo only works in Chrome. I realized it too late, but you get the picture
 
-
-
-
-
-
-
-
 # Non-goals
 
-Things that `elm-starter` is not expected to do 
+Things that `elm-starter` is not expected to do
 
 * Doesn't generate Elm code automatically, like Route-parser, for example
 * Doesn't touch/wrap the code of your Elm Application
 * Doesn't do live SSR (Server Side Render) but just pre-render during the build
 * Doesn't change the Javascript coming out from the Elm compiler
 * Doesn't create a web site based on static files containing Markdown
-* There is no "[hydration](https://developers.google.com/web/updates/2019/02/rendering-on-the-web)", unless Elm does some magic that I am not aware of. 
+* There is no "[hydration](https://developers.google.com/web/updates/2019/02/rendering-on-the-web)", unless Elm does some magic that I am not aware of.
 
 You can find several of these characteristics in some of the [similar projects](#similar-projects).
 
@@ -370,12 +276,6 @@ It cannot help you with
 * Server Rendering
 * SSR with (re)hydration
 
-
-
-
- 
- 
- 
 # Similar projects
 
 These are other projects that can be used to bootstrap an Elm application or to generate a static site:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $ cd my-new-project
 $ rm -rf .git
 $ npm install
 ```
+
 Done! At this point, these are the available commands:
 
 ### `$ npm start`
@@ -120,6 +121,7 @@ Let's suppose your existing project is in `my-elm-app`
 
 * Add `src-elm-starter` as an extra `source-directory` in `elm.json`, the same as in `elm-starter/elm.json`
 * Add these commands to `package.json` (or run them directly)
+
     ```json
       "scripts": {
         "start":       "node ./src-elm-starter/starter.js start",
@@ -127,6 +129,7 @@ Let's suppose your existing project is in `my-elm-app`
         "serverBuild": "node ./src-elm-starter/starter.js serverBuild"
       },
     ```
+
 Done!
 
 ## Netlify
@@ -210,9 +213,11 @@ You can validate Twitter preview cards at [https://cards-dev.twitter.com/validat
 ## Configuration
 
 You can verify the configuration in real-time using elm reactor:
+
 ```sh
 $ node_modules/.bin/elm reactor
 ```
+
 and check the page
 
 [http://localhost:8000/src-elm-starter/Application.elm](http://localhost:8000/src-elm-starter/Application.elm)
@@ -224,6 +229,7 @@ There are three global objects available
 ### `ElmStarter`
 
 `ElmStarter` contain metadata about the app:
+
 ```json
 { commit: "abf04f3"   // coming from git
 , branch: "master"    // coming from git

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Example of the installed version, with and without Javascript enabled:
 
 ![elm-starter](assets/dev/elm-starter.gif)
 
-### Demos
+## Demos
 
 These are three simple examples of websites built with `elm-starter`:
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ The fastest way is to [click here](https://app.netlify.com/start/deploy?reposito
 Otherwise the steps are:
 
 ```sh
-$ git clone https://github.com/lucamug/elm-starter
-$ mv elm-starter my-new-project
-$ cd my-new-project
-$ rm -rf .git
-$ npm install
+git clone https://github.com/lucamug/elm-starter
+mv elm-starter my-new-project
+cd my-new-project
+rm -rf .git
+npm install
 ```
 
 Done! At this point, these are the available commands:
@@ -110,13 +110,13 @@ Let's suppose your existing project is in `my-elm-app`
 * Add `node` dependencies with these commands
 
     ```sh
-    $ npm install --save-dev chokidar-cli
-    $ npm install --save-dev concurrently
-    $ npm install --save-dev elm
-    $ npm install --save-dev elm-live
-    $ npm install --save-dev html-minifier
-    $ npm install --save-dev puppeteer
-    $ npm install --save-dev terser
+    npm install --save-dev chokidar-cli
+    npm install --save-dev concurrently
+    npm install --save-dev elm
+    npm install --save-dev elm-live
+    npm install --save-dev html-minifier
+    npm install --save-dev puppeteer
+    npm install --save-dev terser
     ```
 
 * Add `src-elm-starter` as an extra `source-directory` in `elm.json`, the same as in `elm-starter/elm.json`
@@ -215,7 +215,7 @@ You can validate Twitter preview cards at [https://cards-dev.twitter.com/validat
 You can verify the configuration in real-time using elm reactor:
 
 ```sh
-$ node_modules/.bin/elm reactor
+node_modules/.bin/elm reactor
 ```
 
 and check the page

--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ The working folder of `elm-starter` is `elm-stuff/elm-starter-files`. These file
 ## File generation
 
 * Most of the logic is written in Elm, including the code to generate all necessary files:
-    * `index.html` (generated from [`Index.elm`](https://github.com/lucamug/elm-start-private/blob/master/src/Index.elm) using [`zwilias/elm-html-string`](https://package.elm-lang.org/packages/zwilias/elm-html-string/latest/))
-    * [`sitemap.txt`](https://elm-starter.guupa.com/sitemap.txt)
-    * [`manifest.json`](https://elm-starter.guupa.com/manifest.json)
-    * [`service-worker.js`](https://elm-starter.guupa.com/service-worker.js)
-    * [`robots.txt`](https://elm-starter.guupa.com/robots.txt)
+  * `index.html` (generated from [`Index.elm`](https://github.com/lucamug/elm-start-private/blob/master/src/Index.elm) using [`zwilias/elm-html-string`](https://package.elm-lang.org/packages/zwilias/elm-html-string/latest/))
+  * [`sitemap.txt`](https://elm-starter.guupa.com/sitemap.txt)
+  * [`manifest.json`](https://elm-starter.guupa.com/manifest.json)
+  * [`service-worker.js`](https://elm-starter.guupa.com/service-worker.js)
+  * [`robots.txt`](https://elm-starter.guupa.com/robots.txt)
 
 ## Disabling pre-rendering
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The fastest way is to [click here](https://app.netlify.com/start/deploy?reposito
 
 Otherwise the steps are:
 
-```
+```sh
 $ git clone https://github.com/lucamug/elm-starter
 $ mv elm-starter my-new-project
 $ cd my-new-project
@@ -108,7 +108,7 @@ Let's suppose your existing project is in `my-elm-app`
 
 * Add `node` dependencies with these commands
 
-    ```
+    ```sh
     $ npm install --save-dev chokidar-cli
     $ npm install --save-dev concurrently
     $ npm install --save-dev elm
@@ -120,7 +120,7 @@ Let's suppose your existing project is in `my-elm-app`
 
 * Add `src-elm-starter` as an extra `source-directory` in `elm.json`, the same as in `elm-starter/elm.json`
 * Add these commands to `package.json` (or run them directly)
-    ```
+    ```json
       "scripts": {
         "start":       "node ./src-elm-starter/starter.js start",
         "build":       "node ./src-elm-starter/starter.js build",
@@ -191,7 +191,7 @@ Support [https://github.com/kraklin/elm-debug-transformer](https://github.com/kr
 
 For better SEO, you should update meta-tags using the predefined port `changeMeta` that you can use this way:
 
-```
+```json
 Cmd.batch
     [ changeMeta { querySelector = "title", fieldName = "innerHTML", content = title }
     , changeMeta { querySelector = "meta[property='og:title']", fieldName = "content", content = title }
@@ -210,7 +210,7 @@ You can validate Twitter preview cards at [https://cards-dev.twitter.com/validat
 ## Configuration
 
 You can verify the configuration in real-time using elm reactor:
-```
+```sh
 $ node_modules/.bin/elm reactor
 ```
 and check the page
@@ -224,7 +224,7 @@ There are three global objects available
 ### `ElmStarter`
 
 `ElmStarter` contain metadata about the app:
-```
+```json
 { commit: "abf04f3"   // coming from git
 , branch: "master"    // coming from git
 , env: "dev"          // can be "dev" or "prod"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rm -rf .git
 npm install
 ```
 
-Done! At this point, these are the available commands:
+Done! `elm-starter` is installed. To start using it you must create your own git repository, add files and make a commit (example: `git init && git add . && git commit -m "initial commit"`). At this point, these are the available commands:
 
 ### `$ npm start`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # elm-starter
 
-`elm-starter` is an experimental Elm-based Elm bootstrapper that can also be plugged into already existing Elm applications. 
+`elm-starter` is an experimental Elm-based Elm bootstrapper that can also be plugged into already existing Elm applications.
 
 Post ["elm-starter", a tool for the Modern Web](https://dev.to/lucamug/elm-starter-a-tool-for-the-modern-web-53b1).
 
@@ -120,7 +120,7 @@ Open [http://localhost:9000](http://localhost:9000) to view it in the browser.
 
 Let's suppose your existing project is in `my-elm-app`
 
-* Clone `elm-starter` with<br> 
+* Clone `elm-starter` with  
     `$ git clone https://github.com/lucamug/elm-starter.git`
 * Copy the folder [`elm-starter/src-elm-starter/`](https://github.com/lucamug/elm-starter/tree/master/src-elm-starter) to `my-elm-app/src-elm-starter/`
 * Copy the file [`elm-starter/src/Index.elm`](https://github.com/lucamug/elm-starter/blob/master/src/Index.elm) to `my-elm-app/src/Index.elm`


### PR DESCRIPTION
When following the "Otherwise the steps are" from "How to bootstrap a new project" the npm commands failed due to missing git repository.

Updated REAME with info about creating git repository (line 64) and MarkDown linting according to Visual Studio Code extension markdownlint.

Ways to reproduce:

```sh
$ git clone https://github.com/lucamug/elm-starter
Cloning into 'elm-starter'...
remote: Enumerating objects: 174, done.
remote: Counting objects: 100% (174/174), done.
remote: Compressing objects: 100% (120/120), done.
remote: Total 174 (delta 81), reused 144 (delta 51), pack-reused 0
Receiving objects: 100% (174/174), 1.51 MiB | 3.00 MiB/s, done.
Resolving deltas: 100% (81/81), done.
$ mv elm-starter reproduce-err-elm-starter
$ cd reproduce-err-elm-starter
reproduce-err-elm-starter$ rm -rf .git
reproduce-err-elm-starter$ npm install
reproduce-err-elm-starter$ npm start

> elm-starter@0.0.6 start /path/src/reproduce-err-elm-starter
> node ./src-elm-starter/starter.js start

fatal: not a git repository (or any of the parent directories): .git
child_process.js:642
    throw err;
    ^

Error: Command failed: git rev-parse --short HEAD
fatal: not a git repository (or any of the parent directories): .git
```

Solution/Expected behaviour:

```sh
reproduce-err-elm-starter$ git init
Initialized empty Git repository in /path/src/reproduce-err-elm-starter/.git/
reproduce-err-elm-starter$ git add .
reproduce-err-elm-starter$ git commit -m "initial commit"
Auto packing the repository in background for optimum performance.
See "git help gc" for manual housekeeping.
[master (root-commit) 6a79394] initial commit
 *** cut ***
 create mode 100644 src/Index.elm
 create mode 100644 src/Main.elm
reproduce-err-elm-starter$ npm start

> elm-starter@0.0.6 start /path/src/reproduce-err-elm-starter
> node ./src-elm-starter/starter.js start

 凸 Starting (6a79394, master)...

[1]  凸 Watching elm-starter Elm files...
[1]
[0]  凸 Starting server DEV...
```
